### PR TITLE
fix: fixed plain text payload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You may set a different logging level for the `ObserveHttpSender` class.
 * The `check_connectivity` method that is optional but recommended before attempting to submit large amounts of data to Observe. See example.py for use and docstrings on the method for details.
 * You MUST call the method `flush` before your code completes to ensure all remaining non batch posted data is sent to Observe.
 * Methods `get_pop_empty_fields` and `set_pop_empty_fields`. Defaults to True to remove empty/null fields from payloads to save ingestion cost.
-* Methods `get_payload_json_format` and `set_payload_json_format`. Defaults to True to post payload in format `application/json`. False will post the payload in format `text/plain`
+* Methods `get_payload_json_format` and `set_payload_json_format`. Defaults to True to post payload in format `application/json`. False will post the payload in format `text/plain` Set this at instantiation for text payloads.
 * Methods `get_post_path` and `set_post_path`. Defaults to None append an optional path segment example `/orca/alerts`. This will show in the Datastream EXTRAS field as `path`.
 
 # Example Usage:

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@
 import sys
 
 #: The release version
-version = '1.3.0'
+version = '1.3.1'
 __version__ = version
 
 MIN_PYTHON_VERSION = 3, 7


### PR DESCRIPTION
Fixed the option to post payload as plain/text when set_payload_json_format(False) is called on the instantiated observer object.